### PR TITLE
suggestion for ace incremental damage

### DIFF
--- a/JSHK_contam/functions/main/fn_aceDamage.sqf
+++ b/JSHK_contam/functions/main/fn_aceDamage.sqf
@@ -16,6 +16,25 @@ private _threeQuarterTime = _timeToDeath * 0.75;
 private _coughCond = false;
 private _coughHandle = scriptNull;
 
+// ACE settings, taken from ACE3 - https://github.com/acemod/ACE3/blob/b991fe1343943a869371ef5ba525b6b944b1023d/addons/medical_engine/script_macros_medical.hpp 
+//#define PAIN_UNCONSCIOUS EGVAR(medical,const_painUnconscious);
+private _damageThreshold = GET_DAMAGE_THRESHOLD(_unit);
+private _bodyThreshold = 1.5 * _damageThreshold;
+private _quarterDamage = _bodyThreshold * 0.1; //only doing small damage initial
+private _halfDamage = _bodyThreshold * 0.5;
+private _threeQuarterDamage = _bodyThreshold * 0.75;
+
+// time between dmg reoccurence
+private _dmgTimer = 10; //seconds
+private _fullDmgTimer = 1; //seconds
+private _lastDmgTime = 0;
+
+// always apply dmg when entering a new dmg bracket
+private _quarterFirst = true;
+private _halfFirst = true;
+private _threeQuarterFirst = true;
+
+
 //temp sound til blur////////////////////////////
 {
 	[_unit,_x] say3D ["WoundedGuyA_03",10,1];
@@ -25,12 +44,17 @@ private _coughHandle = scriptNull;
 
 while {alive _unit && (_unit getVariable ["JSHK_contam_damageHandle",false])} do
 {
-	private _timeDiff = time - _initialtime;
+	private _now = time;
+	private _timeDiff = _now - _initialtime;
 	
+	// cough handler
 	if (isNull _coughHandle || scriptDone _coughHandle) then
 	{
 		_coughCond = true;
 	} else { _coughCond = false; };
+
+	//ACE unconsious check
+	private _unitConsious = _unit getVariable ["ACE_isUnconscious", false]
 	
 	switch (true) do
 	{
@@ -46,6 +70,19 @@ while {alive _unit && (_unit getVariable ["JSHK_contam_damageHandle",false])} do
 			{
 				_coughHandle = [_unit,"JSHK_contam_addon_cough1"] spawn JSHK_contam_fnc_playCough;
 			};
+
+			//if consious and time since last dmg infliced is more than threshold do dmg
+			if (_unitConsious && (_now - _lastDmgTime) >= _dmgTimer || _unitConsious && _quarterFirst) then
+			{
+				// set first to false
+				_quarterFirst = false;
+
+				// inflict damage
+				[_unit, _quarterDamage, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
+
+				//save time of dmg inflicted
+				_lastDmgTime = now;
+			}
 		};
 		case (_timeDiff <= _halfTime):
 		{
@@ -58,6 +95,19 @@ while {alive _unit && (_unit getVariable ["JSHK_contam_damageHandle",false])} do
 					_coughHandle = [_unit,"JSHK_contam_addon_cough1"] spawn JSHK_contam_fnc_playCough;
 				};
 			//};
+
+			//if consious and time since last dmg infliced is more than threshold do dmg
+			if (_unitConsious && (_now - _lastDmgTime) >= _dmgTimer || _unitConsious && _halfFirst) then
+			{
+				// set first to false
+				halfFirst = false;
+
+				// inflict damage
+				[_unit, _halfDamage, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
+
+				//save time of dmg inflicted
+				_lastDmgTime = now;
+			}			
 		};
 		case (_timeDiff <= _threeQuarterTime):
 		{
@@ -71,10 +121,35 @@ while {alive _unit && (_unit getVariable ["JSHK_contam_damageHandle",false])} do
 				};
 				if (!isForcedWalk _unit) then {	_unit forceWalk true; };
 			//};	
+
+			//if consious and time since last dmg infliced is more than threshold do dmg
+			if (_unitConsious && (_now - _lastDmgTime) >= _dmgTimer || _unitConsious && _threeQuarterFirst) then
+			{
+				// set first to false
+				_threeQuarterFirst = false;
+
+				// inflict damage
+				[_unit, _threeQuarterDamage, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
+
+				//save time of dmg inflicted
+				_lastDmgTime = now;
+			}			
 		};
 		case (_timeDiff >= _timeToDeath):
 		{
-			[_unit,true] call ace_medical_status_fnc_setCardiacArrestState;
+			//[_unit,true] call ace_medical_status_fnc_setCardiacArrestState;
+
+			// inflict body threshold damage to get unconsious straight away, and to saveguard against odd settings, repeat the dmg every second, until unconcious
+			//  This should also trigger unconsious/cardiac arrest state correctly through ACE 
+			if (_unitConsious && (_now - _lastDmgTime) >= _fullDmgTimer) then
+			{
+				// inflict damage
+				[_unit, _bodyThreshold, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
+
+				//save time of dmg inflicted
+				_lastDmgTime = now;
+			}	
+
 		};
 		default {};
 	};

--- a/JSHK_contam/functions/main/fn_aceDamage.sqf
+++ b/JSHK_contam/functions/main/fn_aceDamage.sqf
@@ -116,9 +116,9 @@ while {alive _unit && (_unit getVariable ["JSHK_contam_damageHandle",false])} do
 			//};	
 
 			//increase damage and damage time, if we haven't
-			if !_halfIncrease then
+			if !_threeQuarterIncrease then
 			{
-				_halfIncrease = true;
+				_threeQuarterIncrease = true;
 				_damage = 0.5; 
 				_dmgTimer = (_timeToDeath * 0.05) max 3;
 				_lastDmgTime = _now;

--- a/JSHK_contam/functions/main/fn_aceDamage.sqf
+++ b/JSHK_contam/functions/main/fn_aceDamage.sqf
@@ -1,5 +1,5 @@
 /*/////////////////////////////////////////////////
-Author: J.Shock
+Author: J.Shock + Crowdedlight
 			   
 File: fn_aceDamage.sqf
 Parameters: unit
@@ -16,24 +16,17 @@ private _threeQuarterTime = _timeToDeath * 0.75;
 private _coughCond = false;
 private _coughHandle = scriptNull;
 
-// ACE settings, taken from ACE3 - https://github.com/acemod/ACE3/blob/b991fe1343943a869371ef5ba525b6b944b1023d/addons/medical_engine/script_macros_medical.hpp 
-//#define PAIN_UNCONSCIOUS EGVAR(medical,const_painUnconscious);
-private _damageThreshold = GET_DAMAGE_THRESHOLD(_unit);
-private _bodyThreshold = 1.5 * _damageThreshold;
-private _quarterDamage = _bodyThreshold * 0.1; //only doing small damage initial
-private _halfDamage = _bodyThreshold * 0.5;
-private _threeQuarterDamage = _bodyThreshold * 0.75;
+private _damage = 0.3; //only doing small damage, default ace settings you can get 10 of these in one go without going down. 
+private _damageEnabled = false; //Don't start doing dmg until the first quarter has passed, as we rely on coughing/pain effects here.
+
+private _quarterIncrease = false;
+private _halfIncrease = false;
+private _threeQuarterIncrease = false;
+private _deathEnabled = false;
 
 // time between dmg reoccurence
-private _dmgTimer = 10; //seconds
-private _fullDmgTimer = 1; //seconds
+private _dmgTimer = (_timeToDeath * 0.1) max 3; //10% of timetodeath, with a minimum of 5s between injuries so people have a chance before they get all the dmg
 private _lastDmgTime = 0;
-
-// always apply dmg when entering a new dmg bracket
-private _quarterFirst = true;
-private _halfFirst = true;
-private _threeQuarterFirst = true;
-
 
 //temp sound til blur////////////////////////////
 {
@@ -54,8 +47,18 @@ while {alive _unit && (_unit getVariable ["JSHK_contam_damageHandle",false])} do
 	} else { _coughCond = false; };
 
 	//ACE unconsious check
-	private _unitConsious = _unit getVariable ["ACE_isUnconscious", false]
-	
+	private _unitUnconsious = _unit getVariable ["ace_isUnconscious", false];
+
+	//damage handler, if its time, and unit is not unconsious, do dmg 
+	if ((_now - _lastDmgTime) >= _dmgTimer && _damageEnabled && !_unitUnconsious) then
+	{
+		//apply damage
+		[_unit, _damage, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
+
+		//save time of dmg inflicted
+		_lastDmgTime = _now;
+	};
+
 	switch (true) do
 	{
 		case (_timeDiff <= _quaterTime):
@@ -71,85 +74,64 @@ while {alive _unit && (_unit getVariable ["JSHK_contam_damageHandle",false])} do
 				_coughHandle = [_unit,"JSHK_contam_addon_cough1"] spawn JSHK_contam_fnc_playCough;
 			};
 
-			//if consious and time since last dmg infliced is more than threshold do dmg
-			if (_unitConsious && (_now - _lastDmgTime) >= _dmgTimer || _unitConsious && _quarterFirst) then
+			//give pain when we are 50% into the quarter period
+			if (!_quarterIncrease && _timeDiff >= (_quaterTime*0.5)) then
 			{
-				// set first to false
-				_quarterFirst = false;
-
-				// inflict damage
-				[_unit, _quarterDamage, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
-
-				//save time of dmg inflicted
-				_lastDmgTime = now;
-			}
+				_quarterIncrease = true;
+				//set pain to 0.5 for severer pain to help signify we are in hot zone
+				[_unit, 0.5] call ace_medical_fnc_adjustPainLevel;
+			};
 		};
 		case (_timeDiff <= _halfTime):
 		{
 			//if !(_unit getVariable ["JSHK_contam_abberPP_enabled",false]) then
 			//{
 				//[_unit,"ABBERATION"] call JSHK_contam_fnc_startPP;
-				[_unit] spawn JSHK_contam_fnc_lucidAnim;
-				if _coughCond then
-				{
-					_coughHandle = [_unit,"JSHK_contam_addon_cough1"] spawn JSHK_contam_fnc_playCough;
-				};
+			[_unit] spawn JSHK_contam_fnc_lucidAnim;
+			if _coughCond then
+			{
+				_coughHandle = [_unit,"JSHK_contam_addon_cough1"] spawn JSHK_contam_fnc_playCough;
+			};
 			//};
 
-			//if consious and time since last dmg infliced is more than threshold do dmg
-			if (_unitConsious && (_now - _lastDmgTime) >= _dmgTimer || _unitConsious && _halfFirst) then
+			//enable damage
+			if !_halfIncrease then
 			{
-				// set first to false
-				halfFirst = false;
-
-				// inflict damage
-				[_unit, _halfDamage, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
-
-				//save time of dmg inflicted
-				_lastDmgTime = now;
-			}			
+				_halfIncrease = true;
+				_damageEnabled = true;
+				_lastDmgTime = _now;
+			};					
 		};
 		case (_timeDiff <= _threeQuarterTime):
 		{
 			//if !(_unit getVariable ["JSHK_contam_wetPP_enabled",false]) then
 			//{
 				//[_unit,"WET"] call JSHK_contam_fnc_startPP;
-				[_unit] spawn JSHK_contam_fnc_lucidAnim;
-				if _coughCond then
-				{
-					_coughHandle = [_unit,"JSHK_contam_addon_cough2"] spawn JSHK_contam_fnc_playCough;
-				};
-				if (!isForcedWalk _unit) then {	_unit forceWalk true; };
+			[_unit] spawn JSHK_contam_fnc_lucidAnim;
+			if _coughCond then
+			{
+				_coughHandle = [_unit,"JSHK_contam_addon_cough2"] spawn JSHK_contam_fnc_playCough;
+			};
+			if (!isForcedWalk _unit) then {	_unit forceWalk true; };
 			//};	
 
-			//if consious and time since last dmg infliced is more than threshold do dmg
-			if (_unitConsious && (_now - _lastDmgTime) >= _dmgTimer || _unitConsious && _threeQuarterFirst) then
+			//increase damage and damage time, if we haven't
+			if !_halfIncrease then
 			{
-				// set first to false
-				_threeQuarterFirst = false;
-
-				// inflict damage
-				[_unit, _threeQuarterDamage, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
-
-				//save time of dmg inflicted
-				_lastDmgTime = now;
-			}			
+				_halfIncrease = true;
+				_damage = 0.5; 
+				_dmgTimer = (_timeToDeath * 0.05) max 3;
+				_lastDmgTime = _now;
+			};					
 		};
 		case (_timeDiff >= _timeToDeath):
-		{
-			//[_unit,true] call ace_medical_status_fnc_setCardiacArrestState;
-
-			// inflict body threshold damage to get unconsious straight away, and to saveguard against odd settings, repeat the dmg every second, until unconcious
-			//  This should also trigger unconsious/cardiac arrest state correctly through ACE 
-			if (_unitConsious && (_now - _lastDmgTime) >= _fullDmgTimer) then
+		{	
+			//set cardiac arrest and force it until we are out of area and this loop is stopped
+			if !_unitUnconsious then 
 			{
-				// inflict damage
-				[_unit, _bodyThreshold, "body", "unknown", _unit] call ace_medical_fnc_addDamageToUnit;
-
-				//save time of dmg inflicted
-				_lastDmgTime = now;
-			}	
-
+				//go into cardiac arrest. Can be zeus healed and be revieved by players
+				["ace_medical_FatalVitals", _this] call CBA_fnc_localEvent;
+			};
 		};
 		default {};
 	};
@@ -160,8 +142,5 @@ if (!isNull _coughHandle) then
 {
 	if (!scriptDone _coughHandle) then { terminate _coughHandle; };
 };
-
-//[_unit] spawn JSHK_contam_fnc_stopPP;
-
 
 _unit forceWalk false;


### PR DESCRIPTION
Based on #3 and the ``ace_medical_fnc_addDamageToUnit`` I made a suggestion for how incremental ace damage could be done to also inflict damage over time in the hot-zone. 

The idea is to keep the 4 cases of quarter, half, three-quarters and final. Whenever one of these cases is entered the first time damage is applied straight away, and then the damage will be repeatably inflicted every 10s. Damage will only be applied if the unit is conscious. 

The damage is based on the ACE setting for threshold before fatal on body. The actual values might need adjusting based on tests. The damage is increased for each case you get closer to ``_timeToDie`` and the final case. In the final case, it does damage that should be equal to the fatal ACE threshold. And that damage is repeated every second until the unit is unconscious. This should ensure that any unit goes unconscious rather quick when they hit the ``_timeToDie``. 

The downside of this approach is that units can go unconscious before the ``_timeToDie`` if they already have wounds, or if the ``_timeToDie`` is long enough so they can be inside the quarter,half and threequarters cases to get multiple wounds they don't treat and they then hit the ACE fatal threshold.

another option is to only use the damage as indicators and all cases besides when hitting ``_TimeToDie`` only does minimal damage just to "indicate" you are in hot-zone with too low MOPP. This should minimize the chance of going unconscious before hitting the ``_TimeToDie`` threshold that then does heavy dmg until unconscious. 


DISCLAIMER: I do not currently have access to my desktop with Arma, and frankly don't know how to test mods locally, so this is not tested at all besides seeing that ``ace_medical_fnc_addDamageToUnit`` works. But was thought as an idea/suggestion to how it could be handled.